### PR TITLE
Improve layout of bar plots for codebases with many frameworks

### DIFF
--- a/swift_code_metrics/_graphics.py
+++ b/swift_code_metrics/_graphics.py
@@ -18,7 +18,7 @@ class Graph:
         plt.title(title)
         plt.ylabel(title)
         opacity = 0.8
-        plotted_data = plt.barh(data[1], data[0], color='blue', alpha=opacity)
+        _ = plt.barh(data[1], data[0], color='blue', alpha=opacity)
         index = np.arange(len(data[1]))
         plt.yticks(index, data[1], fontsize=5, rotation=30)
         self.__render(plt, title)

--- a/swift_code_metrics/_graphics.py
+++ b/swift_code_metrics/_graphics.py
@@ -6,6 +6,7 @@ from functional import seq
 from adjustText import adjust_text
 from math import ceil
 import pygraphviz as pgv
+import numpy as np
 
 
 class Graph:
@@ -16,18 +17,10 @@ class Graph:
     def bar_plot(self, title, data):
         plt.title(title)
         plt.ylabel(title)
-        bar_width = 0.75
-        opacity = 0.4
-        plotted_data = plt.barh(data[1], data[0], bar_width, alpha=opacity)
-
-        texts = []
-        for i, v in enumerate(data[0]):
-            texts.append(plt.text(v, i, f' {str(v)}', va='center', color='blue', size='smaller'))
-
-        adjust_text(texts, autoalign='x', only_move={'text': 'x'})
-
-        plt.legend(plotted_data, data[2], loc='lower right')
-
+        opacity = 0.8
+        plotted_data = plt.barh(data[1], data[0], color='blue', alpha=opacity)
+        index = np.arange(len(data[1]))
+        plt.yticks(index, data[1], fontsize=5, rotation=30)
         self.__render(plt, title)
 
     def pie_plot(self, title, sizes, labels, legend):

--- a/swift_code_metrics/_presenter.py
+++ b/swift_code_metrics/_presenter.py
@@ -13,12 +13,10 @@ class GraphPresenter:
         Renders framework related data to a bar plot.
         """
         sorted_data = sorted(list(map(lambda f: (f_of_framework(f),
-                                                 f.compact_name,
-                                                 f.compact_name_description), list_of_frameworks)),
+                                                 f.name), list_of_frameworks)),
                              key=lambda tup: tup[0])
         plot_data = (list(map(lambda f: f[0], sorted_data)),
-                     list(map(lambda f: f[1], sorted_data)),
-                     list(map(lambda f: f[2], sorted_data)))
+                     list(map(lambda f: f[1], sorted_data)))
 
         self.graph.bar_plot(title, plot_data)
 


### PR DESCRIPTION
## Purpose
Currently some graphs of codebase with many frameworks with similar prefix names are not layout properly. Some of the bars are overlaid, and the legends are difficult to read. For example: 
<img width="827" alt="Screen Shot 2019-04-01 at 18 08 01" src="https://user-images.githubusercontent.com/8698156/55342448-1fb9fe80-54a9-11e9-8b15-7fa7287dde39.png">

This PRs fix the layout of bar chars with a more elegant layout. I removed the legends and added the names on the side, with a small rotation. 

<img width="834" alt="Screen Shot 2019-04-01 at 18 08 09" src="https://user-images.githubusercontent.com/8698156/55342461-25afdf80-54a9-11e9-8987-07111f97d200.png">

NOTE: I added black squares to blur out names because framework names are from a private codebase. 

## Approach
Change layout of Chars to be cleaner. 

## Learning
This is my first PR on a python project, so I am sorry if I am not following some language specific guidelines. Please feel free to request changes. 😄