### PR TITLE
Analyze submodules (part 1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib >= 2
 adjustText < 1
 pygraphviz == 1.5
 pyfunctional == 1.2
+mergedeep == 1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ adjustText < 1
 pygraphviz == 1.5
 pyfunctional == 1.2
 mergedeep == 1.3.0
+dataclasses == 0.7.0

--- a/swift_code_metrics/_analyzer.py
+++ b/swift_code_metrics/_analyzer.py
@@ -61,7 +61,6 @@ class Inspector:
 
     def __append_dependency(self, swift_file: 'SwiftFile'):
         framework = self.__get_or_create_framework(swift_file.framework_name)
-        framework.number_of_files += 1
         Inspector.__add_raw_files(framework=framework, swift_file=swift_file)
         framework.data.append_data(data=SyntheticData(swift_file=swift_file))
         # This covers the scenario where a test framework might contain no tests

--- a/swift_code_metrics/_analyzer.py
+++ b/swift_code_metrics/_analyzer.py
@@ -3,7 +3,7 @@ import json
 
 from ._helpers import AnalyzerHelpers
 from ._parser import SwiftFileParser, SwiftFile
-from ._metrics import Framework, SyntheticData
+from ._metrics import Framework
 from ._report import ReportProcessor
 from functional import seq
 from typing import List, Optional

--- a/swift_code_metrics/_analyzer.py
+++ b/swift_code_metrics/_analyzer.py
@@ -62,7 +62,6 @@ class Inspector:
     def __append_dependency(self, swift_file: 'SwiftFile'):
         framework = self.__get_or_create_framework(swift_file.framework_name)
         Inspector.__add_raw_files(framework=framework, swift_file=swift_file)
-        framework.data.append_data(data=SyntheticData(swift_file=swift_file))
         # This covers the scenario where a test framework might contain no tests
         framework.is_test_framework = swift_file.is_test
 

--- a/swift_code_metrics/_analyzer.py
+++ b/swift_code_metrics/_analyzer.py
@@ -7,6 +7,7 @@ from ._metrics import Framework, SyntheticData
 from ._report import ReportProcessor
 from functional import seq
 from typing import List, Optional
+from mergedeep import merge
 
 
 class Inspector:
@@ -61,6 +62,7 @@ class Inspector:
     def __append_dependency(self, swift_file: 'SwiftFile'):
         framework = self.__get_or_create_framework(swift_file.framework_name)
         framework.number_of_files += 1
+        Inspector.__add_raw_files(framework=framework, swift_file=swift_file)
         framework.data.append_data(data=SyntheticData(swift_file=swift_file))
         # This covers the scenario where a test framework might contain no tests
         framework.is_test_framework = swift_file.is_test
@@ -70,6 +72,14 @@ class Inspector:
             if imported_framework is None:
                 imported_framework = Framework(f)
             framework.append_import(imported_framework)
+
+    @staticmethod
+    def __add_raw_files(framework: 'Framework', swift_file: 'SwiftFile'):
+        paths = str(swift_file.path).split('/')
+        ref_dict = swift_file
+        for key in reversed(paths):
+            ref_dict = {key: ref_dict}
+        merge(framework.raw_files, ref_dict)
 
     def __process_shared_file(self, swift_file: 'SwiftFile', directory: str):
         if not swift_file.is_shared:
@@ -99,4 +109,3 @@ class Inspector:
             if f.name == name:
                 return f
         return None
-

--- a/swift_code_metrics/_helpers.py
+++ b/swift_code_metrics/_helpers.py
@@ -1,8 +1,9 @@
 import re
 import logging
 import json
-from typing import Dict
+from typing import List,Dict
 from functional import seq
+
 
 class Log:
     __logger = logging.getLogger(__name__)
@@ -270,3 +271,13 @@ class JSONReader:
     def read_json_file(path: str) -> Dict:
         with open(path, 'r') as fp:
             return json.load(fp)
+
+
+# Methods
+
+def flatten_nested_dictionary_values(dictionary) -> List:
+    for v in dictionary.values():
+        if isinstance(v, dict):
+            yield from flatten_nested_dictionary_values(v)
+        else:
+            yield v

--- a/swift_code_metrics/_metrics.py
+++ b/swift_code_metrics/_metrics.py
@@ -258,6 +258,7 @@ class Framework:
         self.name = name
         self.number_of_files = 0
         self.data = SyntheticData()
+        self.raw_files = {}
         self.__total_imports = {}
         self.is_test_framework = is_test_framework
 

--- a/swift_code_metrics/_metrics.py
+++ b/swift_code_metrics/_metrics.py
@@ -217,6 +217,11 @@ class SyntheticData:
         )
 
     def __add__(self, data):
+        """
+        Implementation of the `+` operator
+        :param data: An instance of SyntheticData
+        :return: a new instance of SyntheticData
+        """
         return SyntheticData(
             loc=self.loc + data.loc,
             noc=self.noc + data.noc,
@@ -228,6 +233,11 @@ class SyntheticData:
         )
 
     def __sub__(self, data):
+        """
+        Implementation of the `-` operator
+        :param data: An instance of SyntheticData
+        :return: a new instance of SyntheticData
+        """
         return SyntheticData(
             loc=self.loc - data.loc,
             noc=self.noc - data.noc,
@@ -271,10 +281,20 @@ class FrameworkData(SyntheticData):
                                                 AnalyzerHelpers.APPLE_FRAMEWORKS]))
 
     def __add__(self, data):
+        """
+        Implementation of the `+` operator
+        :param data: An instance of FrameworkData
+        :return: a new instance of FrameworkData
+        """
         sd = self.__current_sd().__add__(data=data)
         return FrameworkData.__from_sd(sd=sd, n_o_i=self.n_o_i + data.n_o_i)
 
     def __sub__(self, data):
+        """
+        Implementation of the `-` operator
+        :param data: An instance of FrameworkData
+        :return: a new instance of FrameworkData
+        """
         sd = self.__current_sd().__sub__(data=data)
         return FrameworkData.__from_sd(sd=sd, n_o_i=self.n_o_i - data.n_o_i)
 

--- a/swift_code_metrics/_metrics.py
+++ b/swift_code_metrics/_metrics.py
@@ -1,5 +1,6 @@
 from ._helpers import AnalyzerHelpers, Log, ParsingHelpers, ReportingHelpers, flatten_nested_dictionary_values
 from ._parser import SwiftFile
+from dataclasses import dataclass
 from functional import seq
 from typing import Dict, List, Optional
 
@@ -191,31 +192,51 @@ class Metrics:
                    .list()) > 0
 
 
+@dataclass
 class SyntheticData:
-    def __init__(self, swift_file: Optional['SwiftFile'] = None):
-        self.loc = 0 if swift_file is None else swift_file.loc
-        self.noc = 0 if swift_file is None else swift_file.n_of_comments
-        self.number_of_interfaces = 0 if swift_file is None else len(swift_file.interfaces)
-        self.number_of_concrete_data_structures = 0 if swift_file is None else \
-            len(swift_file.structs + swift_file.classes)
-        self.number_of_methods = 0 if swift_file is None else len(swift_file.methods)
-        self.number_of_tests = 0 if swift_file is None else len(swift_file.tests)
+    """
+    Representation of synthetic code metric data
+    """
+    loc: int = 0
+    noc: int = 0
+    number_of_interfaces: int = 0
+    number_of_concrete_data_structures: int = 0
+    number_of_methods: int = 0
+    number_of_tests: int = 0
 
-    def append_data(self, data: 'SyntheticData'):
-        self.loc += data.loc
-        self.noc += data.noc
-        self.number_of_interfaces += data.number_of_interfaces
-        self.number_of_concrete_data_structures += data.number_of_concrete_data_structures
-        self.number_of_methods += data.number_of_methods
-        self.number_of_tests += data.number_of_tests
+    @classmethod
+    def from_swift_file(cls, swift_file: Optional['SwiftFile'] = None) -> 'SyntheticData':
+        return SyntheticData(
+            loc=0 if swift_file is None else swift_file.loc,
+            noc=0 if swift_file is None else swift_file.n_of_comments,
+            number_of_interfaces=0 if swift_file is None else len(swift_file.interfaces),
+            number_of_concrete_data_structures=0 if swift_file is None else \
+                len(swift_file.structs + swift_file.classes),
+            number_of_methods=0 if swift_file is None else len(swift_file.methods),
+            number_of_tests=0 if swift_file is None else len(swift_file.tests)
+        )
 
-    def remove_data(self, data: 'SyntheticData'):
-        self.loc -= data.loc
-        self.noc -= data.noc
-        self.number_of_interfaces -= data.number_of_interfaces
-        self.number_of_concrete_data_structures -= data.number_of_concrete_data_structures
-        self.number_of_methods -= data.number_of_methods
-        self.number_of_tests -= data.number_of_tests
+    def __add__(self, data):
+        return SyntheticData(
+            loc=self.loc + data.loc,
+            noc=self.noc + data.noc,
+            number_of_interfaces=self.number_of_interfaces + data.number_of_interfaces,
+            number_of_concrete_data_structures=self.number_of_concrete_data_structures
+                                               + data.number_of_concrete_data_structures,
+            number_of_methods=self.number_of_methods + data.number_of_methods,
+            number_of_tests=self.number_of_tests + data.number_of_tests
+        )
+
+    def __sub__(self, data):
+        return SyntheticData(
+            loc=self.loc - data.loc,
+            noc=self.noc - data.noc,
+            number_of_interfaces=self.number_of_interfaces - data.number_of_interfaces,
+            number_of_concrete_data_structures=self.number_of_concrete_data_structures
+                                               - data.number_of_concrete_data_structures,
+            number_of_methods=self.number_of_methods - data.number_of_methods,
+            number_of_tests=self.number_of_tests - data.number_of_tests
+        )
 
     @property
     def poc(self) -> float:
@@ -234,29 +255,71 @@ class SyntheticData:
         }
 
 
+@dataclass()
 class FrameworkData(SyntheticData):
-    def __init__(self, swift_file: Optional['SwiftFile'] = None):
-        super().__init__(swift_file)
-        self.n_o_i = 0 if swift_file is None else\
-            len([imp for imp in swift_file.imports if imp not in AnalyzerHelpers.APPLE_FRAMEWORKS])
+    """
+    Enriched synthetic data
+    """
+    n_o_i: int = 0
+
+    @classmethod
+    def from_swift_file(cls, swift_file: Optional['SwiftFile'] = None) -> 'FrameworkData':
+        sd = SyntheticData.from_swift_file(swift_file=swift_file)
+        return FrameworkData.__from_sd(sd=sd,
+                                       n_o_i=0 if swift_file is None else \
+                                           len([imp for imp in swift_file.imports if imp not in \
+                                                AnalyzerHelpers.APPLE_FRAMEWORKS]))
+
+    def __add__(self, data):
+        sd = self.__current_sd().__add__(data=data)
+        return FrameworkData.__from_sd(sd=sd, n_o_i=self.n_o_i + data.n_o_i)
+
+    def __sub__(self, data):
+        sd = self.__current_sd().__sub__(data=data)
+        return FrameworkData.__from_sd(sd=sd, n_o_i=self.n_o_i - data.n_o_i)
 
     def append_framework(self, f: 'Framework'):
-        super().append_data(data=f.data)
+        sd = f.data
+        self.loc += sd.loc
+        self.noc += sd.noc
+        self.number_of_interfaces += sd.number_of_interfaces
+        self.number_of_concrete_data_structures += sd.number_of_concrete_data_structures
+        self.number_of_methods += sd.number_of_methods
+        self.number_of_tests += sd.number_of_tests
         self.n_o_i += f.number_of_imports
-
-    def remove_data(self, data: 'FrameworkData'):
-        super().remove_data(data=data)
-        self.n_o_i -= data.n_o_i
 
     @property
     def as_dict(self) -> Dict:
         return {**super().as_dict, **{"noi": self.n_o_i}}
 
+    # Private
+
+    def __current_sd(self) -> 'SyntheticData':
+        return SyntheticData(
+            loc=self.loc,
+            noc=self.noc,
+            number_of_interfaces=self.number_of_interfaces,
+            number_of_concrete_data_structures=self.number_of_concrete_data_structures,
+            number_of_methods=self.number_of_methods,
+            number_of_tests=self.number_of_tests
+        )
+
+    @classmethod
+    def __from_sd(cls, sd: 'SyntheticData', n_o_i: int) -> 'FrameworkData':
+        return FrameworkData(
+            loc=sd.loc,
+            noc=sd.noc,
+            number_of_interfaces=sd.number_of_interfaces,
+            number_of_concrete_data_structures=sd.number_of_concrete_data_structures,
+            number_of_methods=sd.number_of_methods,
+            number_of_tests=sd.number_of_tests,
+            n_o_i=n_o_i
+        )
+
 
 class Framework:
     def __init__(self, name: str, is_test_framework: bool = False):
         self.name = name
-        self.data = SyntheticData()
         self.raw_files = {}
         self.__total_imports = {}
         self.is_test_framework = is_test_framework
@@ -277,7 +340,22 @@ class Framework:
             self.__total_imports[framework_import] += 1
 
     @property
+    def data(self) -> SyntheticData:
+        """
+        The metrics data describing the framework
+        :return: an instance of SyntheticData
+        """
+        if self.number_of_files == 0:
+            return SyntheticData()
+        return seq([SyntheticData.from_swift_file(swift_file=sf) for sf in self.__raw_files_data()]) \
+            .reduce(lambda sd1, sd2: sd1 + sd2)
+
+    @property
     def number_of_files(self) -> int:
+        """
+        Number of files in the framework
+        :return: The total number of files in this framework (int)
+        """
         return len(self.__raw_files_data())
 
     @property
@@ -320,11 +398,12 @@ class Framework:
     def __raw_files_data(self) -> List['SwiftFile']:
         return list(flatten_nested_dictionary_values(self.raw_files))
 
+
+@dataclass
 class Dependency:
-    def __init__(self, name: str, dependent_framework: str, number_of_imports: int = 0):
-        self.name = name
-        self.dependent_framework = dependent_framework
-        self.number_of_imports = number_of_imports
+    name: str
+    dependent_framework: str
+    number_of_imports: int = 0
 
     def __eq__(self, other):
         return (self.name == other.name) and \
@@ -341,4 +420,3 @@ class Dependency:
     @property
     def relationship(self) -> str:
         return f'{self.name} > {self.dependent_framework}'
-

--- a/swift_code_metrics/_metrics.py
+++ b/swift_code_metrics/_metrics.py
@@ -1,4 +1,4 @@
-from ._helpers import AnalyzerHelpers, Log, ParsingHelpers, ReportingHelpers
+from ._helpers import AnalyzerHelpers, Log, ParsingHelpers, ReportingHelpers, flatten_nested_dictionary_values
 from ._parser import SwiftFile
 from functional import seq
 from typing import Dict, List, Optional
@@ -256,7 +256,6 @@ class FrameworkData(SyntheticData):
 class Framework:
     def __init__(self, name: str, is_test_framework: bool = False):
         self.name = name
-        self.number_of_files = 0
         self.data = SyntheticData()
         self.raw_files = {}
         self.__total_imports = {}
@@ -276,6 +275,10 @@ class Framework:
             self.__total_imports[framework_import] = 1
         else:
             self.__total_imports[framework_import] += 1
+
+    @property
+    def number_of_files(self) -> int:
+        return len(self.__raw_files_data())
 
     @property
     def imports(self) -> Dict[str, int]:
@@ -312,6 +315,10 @@ class Framework:
     def __filtered_imports(items: 'ItemsView') -> Dict[str, int]:
         return seq(items).filter(lambda f: f[0].name not in AnalyzerHelpers.APPLE_FRAMEWORKS).dict()
 
+    # Private
+
+    def __raw_files_data(self) -> List['SwiftFile']:
+        return list(flatten_nested_dictionary_values(self.raw_files))
 
 class Dependency:
     def __init__(self, name: str, dependent_framework: str, number_of_imports: int = 0):

--- a/swift_code_metrics/_parser.py
+++ b/swift_code_metrics/_parser.py
@@ -6,7 +6,9 @@ from ._helpers import Log
 
 
 class SwiftFile(object):
-    def __init__(self, framework_name: List[str],
+    def __init__(self,
+                 path: str,
+                 framework_name: str,
                  loc: int,
                  imports: List[str],
                  interfaces: List[str],
@@ -18,6 +20,7 @@ class SwiftFile(object):
                  is_test: bool):
         """
         Creates a SwiftFile instance that represents a parsed swift file.
+        :param path: The path of the file being analyzed
         :param framework_name: The framework where the file belongs to.
         :param loc: Lines Of Code
         :param imports: List of imported frameworks
@@ -29,6 +32,7 @@ class SwiftFile(object):
         :param is_shared: True if the file is shared with other frameworks
         :param is_test: True if the file is a test class
         """
+        self.path = path
         self.framework_name = framework_name
         self.loc = loc
         self.imports = imports
@@ -133,6 +137,7 @@ class SwiftFileParser(object):
 
         is_shared_file = len(framework_names) > 1
         return [SwiftFile(
+            path=Path(self.current_subdir.replace(f'{self.base_path}/', '')) / Path(self.file).name,
             framework_name=f,
             loc=loc,
             imports=self.attributes_regex_map[ParsingHelpers.IMPORTS],

--- a/swift_code_metrics/_report.py
+++ b/swift_code_metrics/_report.py
@@ -13,14 +13,14 @@ class ReportProcessor:
         # Shared files
         for _, shared_files in shared_files.items():
             shared_file = shared_files[0]
-            shared_file_data = FrameworkData(swift_file=shared_file)
+            shared_file_data = FrameworkData.from_swift_file(swift_file=shared_file)
             for _ in range((len(shared_files) - 1)):
-                report.shared_code.append_data(shared_file_data)
-                report.total_aggregate.remove_data(shared_file_data)
+                report.shared_code += shared_file_data
+                report.total_aggregate -= shared_file_data
                 if shared_file.is_test:
-                    report.test_framework_aggregate.remove_data(shared_file_data)
+                    report.test_framework_aggregate -= shared_file_data
                 else:
-                    report.non_test_framework_aggregate.remove_data(shared_file_data)
+                    report.non_test_framework_aggregate -= shared_file_data
 
         # Frameworks
         for f in sorted(frameworks, key=lambda fr: fr.name, reverse=False):

--- a/swift_code_metrics/tests/test_helper.py
+++ b/swift_code_metrics/tests/test_helper.py
@@ -164,6 +164,13 @@ class HelpersTests(unittest.TestCase):
     def test_helpers_funcs_reduce_dictionary(self):
         self.assertEqual(3, _helpers.ParsingHelpers.reduce_dictionary({"one": 1, "two": 2}))
 
+    # Additional helpers
+
+    def test_flatten_nested_dictionary_values(self):
+        nested_dictionary = {'group1': {'subGroup1': 1}, 'group2': 2, 'group3': {'subGroup3': {'subSubGroup3': 3}}}
+        flattened_values = list(_helpers.flatten_nested_dictionary_values(nested_dictionary))
+        self.assertEqual([1, 2, 3], flattened_values)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/swift_code_metrics/tests/test_metrics.py
+++ b/swift_code_metrics/tests/test_metrics.py
@@ -30,7 +30,7 @@ class FrameworkTests(unittest.TestCase):
             .for_each(lambda f: self.framework.append_import(f))
 
     def test_representation(self):
-        self.assertEqual(str(self.framework), 'AwesomeName(0 files)')
+        self.assertEqual('AwesomeName(2 files)', str(self.framework))
 
     def test_compact_name_more_than_four_capitals(self):
         test_framework = Framework('FrameworkWithMoreThanFourCapitals')
@@ -53,6 +53,9 @@ class FrameworkTests(unittest.TestCase):
 
     def test_number_of_imports(self):
         self.assertEqual(2, self.framework.number_of_imports)
+
+    def test_number_of_files(self):
+        self.assertEqual(2, self.framework.number_of_files)
 
 
 class DependencyTests(unittest.TestCase):

--- a/swift_code_metrics/tests/test_metrics.py
+++ b/swift_code_metrics/tests/test_metrics.py
@@ -4,6 +4,7 @@ from swift_code_metrics._parser import SwiftFile
 from functional import seq
 
 example_swiftfile = SwiftFile(
+    path='/my/path/class.swift',
     framework_name=['Test'],
     loc=1,
     imports=['Foundation', 'dep1', 'dep2'],
@@ -22,6 +23,9 @@ class FrameworkTests(unittest.TestCase):
     def setUp(self):
         self.frameworks = [Framework('BusinessLogic'), Framework('UIKit'), Framework('Other')]
         self.framework = Framework('AwesomeName')
+        self.framework.raw_files['Group1'] = {}
+        self.framework.raw_files['Group1']['File1'] = example_swiftfile
+        self.framework.raw_files['Group1']['File2'] = example_swiftfile
         seq(self.frameworks) \
             .for_each(lambda f: self.framework.append_import(f))
 
@@ -40,7 +44,7 @@ class FrameworkTests(unittest.TestCase):
         self.assertEqual('n', test_framework.compact_name)
 
     def test_compact_name_description(self):
-        self.assertEqual(self.framework.compact_name_description, 'AN = AwesomeName')
+        self.assertEqual('AN = AwesomeName', self.framework.compact_name_description)
 
     def test_imports(self):
         expected_imports = {self.frameworks[0]: 1,


### PR DESCRIPTION
This is the ground-up work to perform sub-modules analysis (https://github.com/matsoftware/swift-code-metrics/issues/21).

The `SwiftFile` instances are now stored by keeping the path hierarchy and the framework's`SyntheticData` is computed out of the parsed files.