### PR TITLE
Relax version requirements for pyfunctional and numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ install_requires = [
     "matplotlib >= 2",
     "adjustText < 1",
     "pygraphviz > 1.5",
-    "pyfunctional == 1.2",
-    "numpy == 1.22.0",
+    "pyfunctional >= 1.2",
+    "numpy >= 1.22.0",
     "dataclasses"
 ]
 


### PR DESCRIPTION
This change allows tests to pass using Python 3.11.1 by allowing a more recent version of pyfunctional, and prevents a version conflict with numpy in our usage of this tool.  Tests also pass using Python 3.8, 3.9, and 3.10 .